### PR TITLE
Bump develop to cdap 2.6 snapshot dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,12 @@
     <dependency>
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-api</artifactId>
-      <version>2.5.1</version>
+      <version>2.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-unit-test</artifactId>
-      <version>2.5.1</version>
+      <version>2.6.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -45,6 +45,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
+  </repositories>
 
   <build>
     <plugins>


### PR DESCRIPTION
As per described in https://issues.cask.co/browse/CDAP-770.
